### PR TITLE
specify a version to avoid another warning

### DIFF
--- a/lib/HTTP/Tiny/Retry.pm
+++ b/lib/HTTP/Tiny/Retry.pm
@@ -8,6 +8,8 @@ use strict;
 use warnings;
 use Log::ger;
 
+our $VERSION=0.001;
+
 use parent 'HTTP::Tiny';
 
 sub request {


### PR DESCRIPTION
The `$VERSION` needs to be set to avoid another warning:

```
$ perl t.pl
Use of uninitialized value in concatenation (.) or string at /Users/plambert/Library/Perlbrew/perls/perl-5.28.1/lib/5.28.1/HTTP/Tiny.pm line 593.
null
```

This patch seems to fix this.
