### PR TITLE
Fix null return value when all retries fail

### DIFF
--- a/lib/HTTP/Tiny/Retry.pm
+++ b/lib/HTTP/Tiny/Retry.pm
@@ -19,7 +19,7 @@ sub request {
     my $retries = 0;
     my $res;
     while (1) {
-        my $res = $self->SUPER::request($method, $url, $options);
+        $res = $self->SUPER::request($method, $url, $options);
         return $res if $res->{status} !~ /\A[5]/;
         last if $retries >= $config_retries;
         $retries++;


### PR DESCRIPTION
The `$res` variable is masked by the `my $res` in line 22 of `Retry.pm`.  As a result, when all retries fail, the return value is `undef`.

This patch seems to fix this.
